### PR TITLE
Preset MediaWiki email address via OAuth at account registration

### DIFF
--- a/src/oauth/PhutilMediaWikiAuthAdapter.php
+++ b/src/oauth/PhutilMediaWikiAuthAdapter.php
@@ -65,6 +65,12 @@ final class PhutilMediaWikiAuthAdapter extends PhutilOAuth1AuthAdapter {
 		return idx( $info, 'name' );
 	}
 
+	public function getAccountEmail() {
+		$info = $this->getUserInfo();
+		return idx($info, 'email');
+	}
+
+
 	public function getAdapterType() {
 		return 'mediawiki';
 	}
@@ -200,6 +206,7 @@ final class PhutilMediaWikiAuthAdapter extends PhutilOAuth1AuthAdapter {
 		$userinfo['groups'] = $identity->groups;
 		$userinfo['blocked'] = $identity->blocked;
 		$userinfo['editcount'] = $identity->editcount;
+		$userinfo['email'] = $identity->email;
 
 		return $userinfo;
 	}


### PR DESCRIPTION
This is a copy of https://gitlab.wikimedia.org/repos/phabricator/extensions/-/commit/5c4db7107c0a291a17311b2d38b6288fc571ae14